### PR TITLE
Update index.md: `brew cask install` is no longer works

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ To install Octave.app using Homebrew Cask:
 
 ```bash
 brew tap octave-app/octave-app
-brew cask install octave-app
+brew install --cask octave-app
 ```
 
 ### Installing directly with Homebrew


### PR DESCRIPTION
Use `brew install --cask` instead of `brew cask install` .